### PR TITLE
refactor: Replace guaranteed_symbol with fetch_piece

### DIFF
--- a/lib/board.rb
+++ b/lib/board.rb
@@ -44,6 +44,8 @@ class Board
 
     #give piece y coord in grid
     piece.y_pos = @columns[piece_xpos].index(piece)
+    
+    piece
   end
 
   def display_board
@@ -52,7 +54,11 @@ class Board
     count = 5
     grid = []
     6.times do
-      @columns.each {|column| grid << "#{guaranteed_symbol(column[count])}" + ' '}
+      @columns.each_index do |index| 
+        x_pos = index
+        y_pos = count
+        grid << "#{fetch_piece(x_pos, y_pos).symbol}" + ' '
+      end
       count -= 1
       grid << "\n"
     end
@@ -60,11 +66,19 @@ class Board
   end
 
   
-  def guaranteed_symbol(piece)
-    if piece.nil?
-      NullPiece.new.symbol
+  def fetch_piece(x_pos, y_pos)
+    #This method retrives a piece at a given location.
+    #If that location points to a nil, it creates a standin null piece
+    #This null piece can answer the message .symbol 
+
+    piece = @columns[x_pos][y_pos]
+
+    if (x_pos < 0 || y_pos < 0) #prevents negative indices from 'wrapping' the board
+      NullPiece.new 
+    elsif piece.nil? 
+      NullPiece.new
     else
-      piece.symbol
+      piece
     end
   end
 

--- a/spec/board_spec.rb
+++ b/spec/board_spec.rb
@@ -107,24 +107,26 @@ RSpec.describe Board do
     end
   end
 
-  describe '#guaranteed_symbol' do
-    it "returns an 'X', 'O', or '.' " do
+  describe '#fetch_piece' do
+    it "returns a piece" do
       board = Board.new
       board.place_piece('X', 'A')
       board.place_piece('O', 'A')
 
-      piece1 = board.columns[0][0]
-      piece2 = board.columns[0][1]
+      piece1 = board.fetch_piece(0, 0)
+      piece2 = board.fetch_piece(0, 1)
       
       #An element that does not exist
-      piece3 = board.columns[4][3]
+      piece3 = board.fetch_piece(4 ,3)
 
-      symbol = board.guaranteed_symbol(piece1)
-      symbol1 = board.guaranteed_symbol(piece2)
-      symbol2 = board.guaranteed_symbol(piece3)
-      expect(symbol).to eq 'X'
-      expect(symbol1).to eq 'O'
-      expect(symbol2).to eq '.'
+      #A negative index
+      piece4 = board.fetch_piece(-1, 0)
+
+      
+      expect(piece1.symbol).to eq 'X'
+      expect(piece2.symbol).to eq 'O'
+      expect(piece3).to be_a NullPiece
+      expect(piece4).to be_a NullPiece
     end
   end
 


### PR DESCRIPTION
Replaces guaranteed_symbol with fetch_piece. 

Instead of fetching a piece or null piece and immediately calling '.symbol' on it we instead return the piece. This is more flexible and allows us to pass the method coordinates instead of pieces. 