### PR TITLE
fix: Fix win_check not creating null pieces for 'G' column.

### DIFF
--- a/lib/board.rb
+++ b/lib/board.rb
@@ -71,14 +71,14 @@ class Board
     #If that location points to a nil, it creates a standin null piece
     #This null piece can answer the message .symbol 
 
-    piece = @columns[x_pos][y_pos]
+    #piece = @columns[x_pos][y_pos]
 
     if (x_pos < 0 || y_pos < 0) #prevents negative indices from 'wrapping' the board
       NullPiece.new 
-    elsif piece.nil? 
+    elsif @columns[x_pos].nil? || @columns[x_pos][y_pos].nil?
       NullPiece.new
     else
-      piece
+      @columns[x_pos][y_pos]
     end
   end
 

--- a/spec/win_check_spec.rb
+++ b/spec/win_check_spec.rb
@@ -71,7 +71,9 @@ describe WinCheck do
       board.place_piece('X', 'A')
       board.place_piece('O', 'C')
       board.place_piece('X', 'D')
-      piece = board.place_piece('O', 'B')
+      board.place_piece('O', 'B')
+      piece = board.place_piece('X', 'G')
+
       
       win_check = WinCheck.new(board)
 


### PR DESCRIPTION
The null piece would occasionally have a bug. Although some_array[index][invalid_index] was working appropriately, some_array[invalid_index][index] was not. Tweaked the conditional of fetch_piece to solve this problem. 

This is why we would only sometimes see the error. When a piece near the right side of the board would check columns[8] it would error, but otherwise it would not error for checking something like columns[3][1000]. 